### PR TITLE
Propagate LICENSE, copyright from original Space Warps SWAP distribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015, Phil Marshall; 2016, Phil Marshall, Chris Davis; 2017, Michael Laraia, Marco Willi, Darryl Wright, Hugh Dickinson; 2018, Phil Marshall, Chris Davis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -68,8 +68,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'SWAP'
-copyright = '2017, Michael Laraia, Marco Willi, Darryl Wright, Hugh Dickinson'
-author = 'Michael Laraia, Marco Willi, Darryl Wright, Hugh Dickinson'
+copyright = '2015, Phil Marshall; 2016, Phil Marshall, Chris Davis; 2017, Michael Laraia, Marco Willi, Darryl Wright, Hugh Dickinson; 2018, Phil Marshall, Chris Davis'
+author = 'Phil Marshall, Chris Davis, Michael Laraia, Marco Willi, Darryl Wright, Hugh Dickinson'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -164,7 +164,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (master_doc, 'SWAP.tex', 'SWAP Documentation',
-     'Michael Laraia, Marco Willi, Darryl Wright, Hugh Dickinson', 'manual'),
+     'Michael Laraia, Marco Willi, Darryl Wright, Hugh Dickinson, Phil Marshall, Chris Davis', 'manual'),
 ]
 
 


### PR DESCRIPTION
Hi there,

Aprajita Verma @aprajita, Chris Davis @cpadavis and I are working on getting SWAP running on Panoptes output together - proposed modifications to the `swap` code will come via PR from Chris. He's in touch with @marten directly. 

Meanwhile, I noticed that the copyright info and LICENSE file got left behind when the original SWAP code from the Space Warps science team repo at https://github.com/drphilmarshall/SpaceWarps got copied into this new and improved `swap` repo, so here's a small PR that fixes this.  

Cc-ing @chrislintott as Zooniverse overseer and also our fellow `swap` authors Michael Laraia @miclaraia , Marco Willi @marco-willi , Darryl Wright @dwright04 Hugh Dickinson @hughdickinson - Thanks for all the work on re-packaging etc! We're excited to see `swap` and Caesar working together in our upcoming SW run :-)

Best wishes,

Phil